### PR TITLE
Renamed the Items array that is sent in post

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -230,15 +230,15 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		
 		
 		//@TODO Need to optimize this to eliminate some of the resource load could use raw queries to be more efficient
-		$data['Items'] = explode(',', $data['Items']);
-		for($sort = 0;$sort<count($data['Items']);$sort++) {
-			$id = intval($data['Items'][$sort]);
+		$ids = explode(',', $data['ItemIDs']);
+		for($sort = 0;$sort<count($ids);$sort++) {
+			$id = intval($ids[$sort]);
 			if ($many_many) {
 				DB::query('UPDATE "' . $table
 						. '" SET "' . $sortColumn.'" = ' . (($sort + 1) + $pageOffset)
 						. ' WHERE "' . $componentField . '" = ' . $id . ' AND "' . $parentField . '" = ' . $owner->ID);
 			} else {
-				$obj = $items->byID($data['Items'][$sort]);
+				$obj = $items->byID($ids[$sort]);
 				$obj->$sortColumn = ($sort + 1) + $pageOffset;
 				$obj->write();
 			}

--- a/javascript/GridFieldSortableRows.js
+++ b/javascript/GridFieldSortableRows.js
@@ -41,7 +41,7 @@
 																					value: button.val()
 																				},
 																				{
-																					name: 'Items',
+																					name: 'ItemIDs',
 																					value: dataRows
 																				}
 																			]});


### PR DESCRIPTION
Renamed the Items array that is sent in post, as it was being overriden by another postvar called Items, containing GridState data. The array of Item Ids used by SortableGridField is now called ItemIDs.

I came across this problem when using my DynamicLists module. I followed your exact HasManyExample but, do let me know if you think it was something I was doing wrong and not something that needed changing on your module ;)

http://github.com/sheadawson/silverstripe-dynamiclists/
