### PR TITLE
Fixes fixSortColumn's Random Initial Sorting

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -153,7 +153,7 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		
 		
 		$max = $list->Max($this->sortColumn);
-		$list=$list->filter($this->sortColumn, 0);
+		$list=$list->filter($this->sortColumn, 0)->sort("Created,ID");
 		if($list->Count()>0) {
 			$owner = $gridField->Form->getRecord();
 			$sortColumn = $this->sortColumn;


### PR DESCRIPTION
When loading a GridField with several new items without a sort order (e.g. after uploading 10 images via GridFieldBulkEditingTools), it would previously apply a seemingly random order to them. This fix ensures that the order applied is the same order as the items were created (or uploaded) in.

**BEFORE:**
![](http://spdr.me/AsDb+)

**AFTER:**
![](http://spdr.me/i9fz+)
