### PR TITLE
Initial sorting equals sortColumn

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -99,7 +99,7 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		$headerState = $gridField->State->GridFieldSortableHeader;
 		$state = $gridField->State->GridFieldSortableRows;
 		if ((!is_bool($state->sortableToggle) || $state->sortableToggle==false) && $headerState && !empty($headerState->SortColumn)) {
-			return $dataList;
+			return $dataList->sort($this->sortColumn);
 		}
 		
 		if ($state->sortableToggle == true) {


### PR DESCRIPTION
After a user has changed sorting order of DataObjects in the list, and when drag&drop is disabled, sorting is made by $default_sort from that DataObjects property or default set by SS. This results in different sorting when checkbox is enabled or disabled what confuses users. This change always sorts the list by $sortColumn, so that user always sees same sorting.
