### PR TITLE
Versioned fix

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -213,38 +213,57 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 				if($many_many) {
 					if($this->append_to_top) {
 						//Upgrade all the records (including the last inserted from 0 to 1)
-						DB::query('UPDATE "' . $table
-								. '" SET "' . $sortColumn . '" = "' . $sortColumn .'"+1'
-								. ' WHERE "' . $parentField . '" = ' . $owner->ID . (!empty($topIncremented) ? ' AND "' . $componentField . '" NOT IN(\''.implode('\',\'', $topIncremented).'\')':''));
-						
+						$queryPrefix = 'UPDATE "' . $table;
+						$querySuffix = '" SET "' . $sortColumn . '" = "' . $sortColumn .'"+1'
+								. ' WHERE "' . $parentField . '" = ' . $owner->ID . (!empty($topIncremented) ? ' AND "' . $componentField . '" NOT IN(\''.implode('\',\'', $topIncremented).'\')':'');
+						DB::query($queryPrefix.$querySuffix);
 						$topIncremented[]=$obj->ID;
+
+						
 					}else {
 						//Append the last record to the bottom
-						DB::query('UPDATE "' . $table
-								. '" SET "' . $sortColumn .'" = ' . ($max + $i)
-								. ' WHERE "' . $componentField . '" = ' . $obj->ID . ' AND "' . $parentField . '" = ' . $owner->ID);
+							$queryPrefix = 'UPDATE "' . $table;
+						$querySuffix = '" SET "' . $sortColumn .'" = ' . ($max + $i)
+								. ' WHERE "' . $componentField . '" = ' . $obj->ID . ' AND "' . $parentField . '" = ' . $owner->ID;
+						DB::query($queryPrefix.$querySuffix);
+
+						
 					}
 				}else if($this->append_to_top) {
 					//Upgrade all the records (including the last inserted from 0 to 1)
-					DB::query('UPDATE "' . $table
-							. '" SET "' . $sortColumn . '" = "' . $sortColumn .'"+1'
-							. ' WHERE '.($list instanceof RelationList ? '"' . $list->foreignKey . '" = '. $owner->ID:$idCondition) . (!empty($topIncremented) ? ' AND "ID" NOT IN(\''.implode('\',\'', $topIncremented).'\')':''));
+					$queryPrefix = 'UPDATE "' . $table;
+					$querySuffix = '" SET "' . $sortColumn . '" = "' . $sortColumn .'"+1'
+							. ' WHERE '.($list instanceof RelationList ? '"' . $list->foreignKey . '" = '. $owner->ID:$idCondition) . (!empty($topIncremented) ? ' AND "ID" NOT IN(\''.implode('\',\'', $topIncremented).'\')':'');
 					
+					DB::query($queryPrefix.$querySuffix);
+					if($obj->has_extension('Versioned')){
+						$queryPrefixLive = 'UPDATE "' . $table.'_Live';
+						DB::query($queryPrefixLive.$querySuffix);
+					}
+
 					//LastEdited
 					DB::query('UPDATE "' . $baseDataClass
 							. '" SET "LastEdited" = \'' . date('Y-m-d H:i:s') . '\''
-							. ' WHERE '.($list instanceof RelationList ? '"' . $list->foreignKey . '" = '. $owner->ID:$idCondition) . (!empty($topIncremented) ? ' AND "ID" NOT IN(\''.implode('\',\'', $topIncremented).'\')':''));		
+							. ' WHERE '.($list instanceof RelationList ? '"' . $list->foreignKey . '" = '. $owner->ID:$idCondition) . (!empty($topIncremented) ? ' AND "ID" NOT IN(\''.implode('\',\'', $topIncremented).'\')':''));
 					
 					$topIncremented[]=$obj->ID;
+
 				}else {
 					//Append the last record to the bottom
-					DB::query('UPDATE "' . $table
-							 . '" SET "' . $sortColumn . '" = ' . ($max + $i)
-							 . ' WHERE "ID" = '. $obj->ID);
+					$queryPrefix = 'UPDATE "' . $table;
+					$querySuffix = '" SET "' . $sortColumn . '" = ' . ($max + $i)
+							 . ' WHERE "ID" = '. $obj->ID;
+					DB::query($queryPrefix.$querySuffix);
+					if($obj->has_extension('Versioned')){
+						$queryPrefixLive = 'UPDATE "' . $table.'_Live';
+						DB::query($queryPrefixLive.$querySuffix);
+					}
+					
 					//LastEdited
 					DB::query('UPDATE "' . $baseDataClass
 							 . '" SET "LastEdited" = \'' . date('Y-m-d H:i:s') . '\''
 							 . ' WHERE "ID" = '. $obj->ID);
+
 				}
 				
 				$i++;
@@ -376,17 +395,25 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		for($sort = 0;$sort<count($ids);$sort++) {
 			$id = intval($ids[$sort]);
 			if ($many_many) {
-				DB::query('UPDATE "' . $table
-						. '" SET "' . $sortColumn.'" = ' . (($sort + 1) + $pageOffset)
-						. ' WHERE "' . $componentField . '" = ' . $id . ' AND "' . $parentField . '" = ' . $owner->ID);
+					$queryPrefix = 'UPDATE "' . $table;
+				$querySuffix = '" SET "' . $sortColumn.'" = ' . (($sort + 1) + $pageOffset)
+						. ' WHERE "' . $componentField . '" = ' . $id . ' AND "' . $parentField . '" = ' . $owner->ID;
+				DB::query($queryPrefix.$querySuffix);
+
 			} else {
-				DB::query('UPDATE "' . $table
-						. '" SET "' . $sortColumn . '" = ' . (($sort + 1) + $pageOffset)
-						. ' WHERE "ID" = '. $id);
-				
+
+	             $queryPrefix = 'UPDATE "' . $table;
+				$querySuffix = '" SET "' . $sortColumn . '" = ' . (($sort + 1) + $pageOffset)
+						. ' WHERE "ID" = '. $id;
+				DB::query($queryPrefix.$querySuffix);
+				if($items->First()->has_extension('Versioned')){
+					$queryPrefixLive = 'UPDATE "' . $table.'_Live';
+					DB::query($queryPrefixLive.$querySuffix);
+				}
 				DB::query('UPDATE "' . $baseDataClass
 						. '" SET "LastEdited" = \'' . date('Y-m-d H:i:s') . '\''
 						. ' WHERE "ID" = '. $id);
+
 			}
 		}
 		
@@ -475,9 +502,15 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		
 		if($data['Target']=='previouspage') {
 			if ($many_many) {
-				DB::query('UPDATE "' . $table
-						. '" SET "' . $sortColumn.'" = ' . $sortPositions[0]
-						. ' WHERE "' . $componentField . '" = ' . $targetItem->ID . ' AND "' . $parentField . '" = ' . $owner->ID);
+
+				$queryPrefix = 'UPDATE "' . $table;
+				$querySuffix = '" SET "' . $sortColumn.'" = ' . $sortPositions[0]
+						. ' WHERE "' . $componentField . '" = ' . $targetItem->ID . ' AND "' . $parentField . '" = ' . $owner->ID;
+				DB::query($queryPrefix.$querySuffix);
+
+
+
+				
 			} else {
 				$targetItem->$sortColumn = $sortPositions[0];
 				$targetItem->write();
@@ -492,9 +525,11 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 				
 				
 				if ($many_many) {
-					DB::query('UPDATE "' . $table
-							. '" SET "' . $sortColumn.'" = ' . $sortPositions[$i]
-							. ' WHERE "' . $componentField . '" = ' . $obj->ID . ' AND "' . $parentField . '" = ' . $owner->ID);
+					$queryPrefix = 'UPDATE "' . $table;
+					$querySuffix = '" SET "' . $sortColumn.'" = ' . $sortPositions[$i]
+							. ' WHERE "' . $componentField . '" = ' . $obj->ID . ' AND "' . $parentField . '" = ' . $owner->ID;
+					DB::query($queryPrefix.$querySuffix);
+				
 				} else {
 					$obj->$sortColumn = $sortPositions[$i];
 					$obj->write();
@@ -504,9 +539,10 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 			}
 		} else {
 			if ($many_many) {
-				DB::query('UPDATE "' . $table
-						. '" SET "' . $sortColumn.'" = ' . $sortPositions[count($sortPositions) - 1]
-						. ' WHERE "' . $componentField . '" = ' . $targetItem->ID . ' AND "' . $parentField . '" = ' . $owner->ID);
+				$queryPrefix = 'UPDATE "' . $table;
+				$querySuffix = '" SET "' . $sortColumn.'" = ' . $sortPositions[count($sortPositions) - 1]
+						. ' WHERE "' . $componentField . '" = ' . $targetItem->ID . ' AND "' . $parentField . '" = ' . $owner->ID;
+				DB::query($queryPrefix.$querySuffix);
 			} else {
 				$targetItem->$sortColumn = $sortPositions[count($sortPositions) - 1];
 				$targetItem->write();
@@ -521,9 +557,10 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 				
 				
 				if ($many_many) {
-					DB::query('UPDATE "' . $table
-							. '" SET "' . $sortColumn.'" = ' . $sortPositions[$i]
-							. ' WHERE "' . $componentField . '" = ' . $obj->ID . ' AND "' . $parentField . '" = ' . $owner->ID);
+					$queryPrefix = 'UPDATE "' . $table;
+					$querySuffix = '" SET "' . $sortColumn.'" = ' . $sortPositions[$i]
+							. ' WHERE "' . $componentField . '" = ' . $obj->ID . ' AND "' . $parentField . '" = ' . $owner->ID;
+					DB::query($queryPrefix.$querySuffix);
 				} else {
 					$obj->$sortColumn = $sortPositions[$i];
 					$obj->write();

--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -585,4 +585,3 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		}
 	}
 }
-?>


### PR DESCRIPTION
This fix solves the broken support for versioned dataobjects like Sitetree (Page) decedents. 
Say if Product is a decedent of Page. When you sort them, it updates Product table but not Product_Live.
The changes in this fix make sure the sortable int field is also updated in the _Live table. 
It should not affect anything else because it checks to see if it versioned data object and then appends _Live to the table name. 