### PR TITLE
Allow 'disableSelection' to be disabled

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -6,13 +6,16 @@
  */
 class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionProvider, GridField_DataManipulator {
 	protected $sortColumn;
+	protected $disable_selection=true;
 	protected $append_to_top=false;
-	
+
 	/**
 	 * @param String $sortColumn Column that should be used to update the sort information
+	 * @param bool   $disableSelection
 	 */
-	public function __construct($sortColumn) {
+	public function __construct($sortColumn, $disableSelection = true) {
 		$this->sortColumn = $sortColumn;
+		$this->disable_selection = $disableSelection;
 	}
 	
 	/**
@@ -80,7 +83,7 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		Requirements::javascript(SORTABLE_GRIDFIELD_BASE . '/javascript/GridFieldSortableRows.js');
 		
 		
-		$args = array('Colspan' => count($gridField->getColumns()), 'ID' => $gridField->ID());
+		$args = array('Colspan' => count($gridField->getColumns()), 'ID' => $gridField->ID(), 'DisableSelection' => $this->disable_selection);
 		
 		return array('header' => $forTemplate->renderWith('GridFieldSortableRows', $args));
 	}
@@ -117,6 +120,15 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 	 */
 	public function setAppendToTop($value) {
 		$this->append_to_top=$value;
+		return $this;
+	}
+
+	/**
+	 * @param bool $value Boolean true to disable selection of table contents false to enable selection
+	 * @return GridFieldSortableRows Returns the current instance
+	 */
+	public function setDisableSelection($value){
+		$this->disable_selection = $value;
 		return $this;
 	}
 	

--- a/javascript/GridFieldSortableRows.js
+++ b/javascript/GridFieldSortableRows.js
@@ -60,7 +60,11 @@
 																				form.removeClass('loading');
 																			});
 												}
-											}).disableSelection();
+											});
+
+				if(refCheckbox.hasClass('gridfield-sortablerows-noselection')){
+					gridField.find('tbody').disableSelection();
+				}
 				
 				gridField.find('.datagrid-pagination .ss-gridfield-previouspage, .datagrid-pagination .ss-gridfield-nextpage').each(function() {
 																$(this).droppable({

--- a/templates/Includes/GridFieldSortableRows.ss
+++ b/templates/Includes/GridFieldSortableRows.ss
@@ -1,10 +1,11 @@
 <tr>
 	<th class="extra sortablerowsheading" colspan="$Colspan">
 		<div class="gridfield-sortablerows">
-			 <input type="checkbox" id="{$ID}_AllowDragDropCheck" value="1" class="no-change-track"$Checked/> <label for="{$ID}_AllowDragDropCheck"><%t GridFieldSortableRows.ALLOW_DRAG_DROP "Allow drag and drop re-ordering" %></label>
-			 $SortableToggle
-			 $SortOrderSave
-             $SortToPage
+			<input type="checkbox" id="{$ID}_AllowDragDropCheck" value="1" class="no-change-track<% if $DisableSelection %> gridfield-sortablerows-noselection<% end_if %>"$Checked/>
+			<label for="{$ID}_AllowDragDropCheck"><%t GridFieldSortableRows.ALLOW_DRAG_DROP "Allow drag and drop re-ordering" %></label>
+			$SortableToggle
+			$SortOrderSave
+			$SortToPage
 		</div>
 	</th>
 </tr>


### PR DESCRIPTION
Currently disableSelection is always enabled.
This is useful for the drap/drop function, however in firefox this disables the ability to use GridfieldEditableColumns as you cannot focus the inputs.

This pull request allows you to either pass `false` as the second parameter to the constructor - or use `->setDisableSelection(false)` to disable the disableSelection() call.

I had considered changing the behaviour so `disableSelection()` is called when you enable drag/drop and `enableSelection()` is called when you disable drag/drop but this still produces inconsistent results across browsers.

This change is 100% backwards compatible as the default is to enable `disableSelection()`