### PR TITLE
Use Sort of GridField Header

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -119,7 +119,7 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		$headerState = $gridField->State->GridFieldSortableHeader;
 		$state = $gridField->State->GridFieldSortableRows;
 		if ((!is_bool($state->sortableToggle) || $state->sortableToggle==false) && $headerState && !empty($headerState->SortColumn)) {
-			return $dataList->sort($this->sortColumn);
+			return $dataList->sort($headerState->SortColumn);
 		}
 		
 		if ($state->sortableToggle == true) {


### PR DESCRIPTION
When not in 'Drag&Drop reordering' mode ('sortableToggle' is false) and a SortColumn is set by GridField's header, this last one should be used; otherwise, when the user clicks on a sortable header, the list is reloaded and the header shows a up/down sorting arrow, but this doesn't reflect the actual sorting.