### PR TITLE
Remove closing PHP tag

### DIFF
--- a/code/forms/GridFieldSortableRows.php
+++ b/code/forms/GridFieldSortableRows.php
@@ -678,4 +678,3 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 		}
 	}
 }
-?>


### PR DESCRIPTION
To prevent whitespace being sent after the closing tag