### PR TITLE
Fixes "undefined offset" error when moving a many_many item to previous page

### DIFF
--- a/src/Forms/GridFieldSortableRows.php
+++ b/src/Forms/GridFieldSortableRows.php
@@ -656,7 +656,7 @@ class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionP
 
             $i = 1;
             foreach ($items as $obj) {
-                if ($obj->ID == $targetItem->ID) {
+                if ($obj->ID == $targetItem->ID || $i >= count($sortPositions)) {
                     continue;
                 }
 


### PR DESCRIPTION
When viewing the last page of a list of data objects, trying to move one of them to the previous page triggers an "undefined offset" error.

It tries to update an object at an index past the end of the $sortPosition array, so it needs to exit the loop at that point.