### PR TITLE
NEW Extend new AbstractGridFieldComponent class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": "~4.0",
+		"silverstripe/framework": "~4.11",
 		"silverstripe/versioned": "^1.0",
         "silverstripe/vendor-plugin": "^1.0"
 	},

--- a/docs/HasManyExample.md
+++ b/docs/HasManyExample.md
@@ -17,16 +17,16 @@ class TestPage extends Page
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
-        
+
         $conf = GridFieldConfig_RelationEditor::create(10);
-        $conf->addComponent(new GridFieldSortableRows('SortOrder'));
+        $conf->addComponent(GridFieldSortableRows::create('SortOrder'));
 
         $fields->addFieldToTab(
-            'Root.TestObjects', 
+            'Root.TestObjects',
             GridField::create(
-                'TestObjects', 
-                'TestObjects', 
-                $this->TestObjects(), 
+                'TestObjects',
+                'TestObjects',
+                $this->TestObjects(),
                 $conf
             )
         );

--- a/docs/ManyManyExample.md
+++ b/docs/ManyManyExample.md
@@ -25,9 +25,9 @@ class TestPage extends Page
 		$fields = parent::getCMSFields();
 
 		$conf = GridFieldConfig_RelationEditor::create(10);
-		$conf->addComponent(new GridFieldSortableRows('SortOrder'));
+		$conf->addComponent(GridFieldSortableRows::create('SortOrder'));
 
-		$fields->addFieldToTab('Root.TestObjects', new GridField('TestObjects', 'TestObjects', $this->TestObjects(), $conf));
+		$fields->addFieldToTab('Root.TestObjects', GridField::create('TestObjects', 'TestObjects', $this->TestObjects(), $conf));
 
 		return $fields;
 	}

--- a/docs/ModelAdminExample.md
+++ b/docs/ModelAdminExample.md
@@ -10,24 +10,24 @@ use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
 class MyModelAdmin extends ModelAdmin
 {
     private static $menu_title = 'My Model Admin';
-    
+
     private static $url_segment = 'my-model-admin';
-    
+
     private static $managed_models = [
         MATestObject::class,
     ];
-    
+
     public function getEditForm($id = null, $fields = null)
     {
         $form = parent::getEditForm($id, $fields);
-        
+
         // This check is simply to ensure you are on the managed model you want adjust accordingly
         if ($this->modelClass === MATestObject::class) {
             $gridField = $form->Fields()->dataFieldByName($this->sanitiseClassName($this->modelClass));
-            
+
             // This is just a precaution to ensure we got a GridField from dataFieldByName() which you should have
             if ($gridField instanceof GridField) {
-                $gridField->getConfig()->addComponent(new GridFieldSortableRows('SortOrder'));
+                $gridField->getConfig()->addComponent(GridFieldSortableRows::create('SortOrder'));
             }
         }
 
@@ -44,7 +44,7 @@ class MATestObject extends DataObject
         'Title' => 'Varchar',
         'SortOrder' => 'Int',
     ];
-    
+
     private static $indexes = [
         'SortOrder' => true,
     ];

--- a/src/Forms/GridFieldSortableRows.php
+++ b/src/Forms/GridFieldSortableRows.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_DataManipulator;
@@ -36,7 +37,7 @@ use SilverStripe\View\Requirements;
  *
  * @package forms
  */
-class GridFieldSortableRows implements GridField_HTMLProvider, GridField_ActionProvider, GridField_DataManipulator
+class GridFieldSortableRows extends AbstractGridFieldComponent implements GridField_HTMLProvider, GridField_ActionProvider, GridField_DataManipulator
 {
     /** @var string */
     protected $sortColumn;


### PR DESCRIPTION
This makes the `GridFieldSortableRows` component `Injectable`, and allows any future enhancements in the new abstract class to automatically apply without requiring additional changes in this module.

The class is introduced in silverstripe/framework 4.11.0 (see silverstripe/silverstripe-framework#10204) so the dependency constraint needs to be updated.

Some whitespace issues have also been fixed automatically by my IDE.